### PR TITLE
feat(designer): add node selection, collapsible panels, grid backgrond and localStorage persistence

### DIFF
--- a/app/designer/ConnectionLine.tsx
+++ b/app/designer/ConnectionLine.tsx
@@ -151,6 +151,26 @@ export function BezierConnection({
           ref.setAttr("_toX", toX);
           ref.setAttr("_toY", toY);
           ref.setAttr("_waypoints", waypoints);
+          // Provide bounding rect so Konva's Group visibility check
+          // doesn't cull connections when the canvas origin is off-screen
+          ref.getSelfRect = () => {
+            const fx = ref.getAttr("_fromX") ?? fromX;
+            const fy = ref.getAttr("_fromY") ?? fromY;
+            const tx = ref.getAttr("_toX") ?? toX;
+            const ty = ref.getAttr("_toY") ?? toY;
+            const wps: Waypoint[] = ref.getAttr("_waypoints") ?? waypoints;
+            const allX = [fx, tx, ...wps.map((w) => w.x)];
+            const allY = [fy, ty, ...wps.map((w) => w.y)];
+            const pad = 60;
+            const minX = Math.min(...allX) - pad;
+            const minY = Math.min(...allY) - pad;
+            return {
+              x: minX,
+              y: minY,
+              width: Math.max(...allX) - minX + pad,
+              height: Math.max(...allY) - minY + pad,
+            };
+          };
           shapeRefs.current!.set(connKey, ref);
         } else {
           shapeRefs.current!.delete(connKey);
@@ -181,8 +201,8 @@ export function BezierConnection({
         const pointer = stage.getPointerPosition();
         if (!pointer) return;
         const s = stage.scaleX();
-        const x = pointer.x / s;
-        const y = pointer.y / s;
+        const x = (pointer.x - stage.x()) / s;
+        const y = (pointer.y - stage.y()) / s;
 
         const allPoints = [
           { x: fromX, y: fromY },

--- a/app/designer/DesignerCanvas.tsx
+++ b/app/designer/DesignerCanvas.tsx
@@ -1,23 +1,100 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Stage, Layer } from "react-konva";
+import { useState, useCallback, useEffect } from "react";
+import { Stage, Layer, Shape } from "react-konva";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type Konva from "konva";
-import { initialNodes, initialConnections, type NodeType } from "./designer-data";
-import { NODE_W, NODE_H } from "./constants";
+import { initialNodes, initialConnections, type NodeType, type CanvasNode, type Connection } from "./designer-data";
+import { NODE_W, NODE_H, GRID_SIZE, EQUIPMENT_MIME_TYPE } from "./constants";
 import { useCanvasNodes } from "./useCanvasNodes";
 import { useConnections } from "./useConnections";
 import { ConnectionGroup, ConnectionPreview } from "./ConnectionLine";
 import NodeShape from "./NodeShape";
 import ZoomControls, { useCanvasViewport } from "./ZoomControls";
 
-export default function DesignerCanvas() {
-  const { nodes, commitNodePosition, addNode } = useCanvasNodes(initialNodes);
+// --- Grid dots background ---
+function CanvasGrid({
+  scale,
+  stagePos,
+  stageSize,
+}: {
+  scale: number;
+  stagePos: { x: number; y: number };
+  stageSize: { width: number; height: number };
+}) {
+  // Adaptive step: ensure dots are ≥15px apart on screen
+  let step = GRID_SIZE;
+  while (step * scale < 15) step *= 2;
+
+  const left = Math.floor(-stagePos.x / scale / step) * step;
+  const top = Math.floor(-stagePos.y / scale / step) * step;
+  const right = left + stageSize.width / scale + step;
+  const bottom = top + stageSize.height / scale + step;
+  const dotRadius = 1.5 / scale;
+
+  return (
+    <Shape
+      sceneFunc={(ctx, shape) => {
+        ctx.beginPath();
+        for (let x = left; x <= right; x += step) {
+          for (let y = top; y <= bottom; y += step) {
+            ctx.moveTo(x + dotRadius, y);
+            ctx.arc(x, y, dotRadius, 0, Math.PI * 2);
+          }
+        }
+        ctx.fillStrokeShape(shape);
+      }}
+      fill="#D1D5DB"
+      listening={false}
+      perfectDrawEnabled={false}
+    />
+  );
+}
+
+export default function DesignerCanvas({
+  onSelectionChange,
+  onNodesChange,
+  onConnectionsChange,
+}: {
+  onSelectionChange?: (nodes: CanvasNode[]) => void;
+  onNodesChange?: (nodes: CanvasNode[]) => void;
+  onConnectionsChange?: (connections: Connection[]) => void;
+}) {
+  const { nodes, selectedNodes, selectNode, deleteSelectedNodes, commitNodePosition, addNode } =
+    useCanvasNodes(initialNodes);
+
+  // Report state changes to parent
+  useEffect(() => {
+    onSelectionChange?.(nodes.filter((n) => selectedNodes.includes(n.id)));
+  }, [selectedNodes, nodes, onSelectionChange]);
+
+  useEffect(() => {
+    onNodesChange?.(nodes);
+  }, [nodes, onNodesChange]);
+
   const conn = useConnections(initialConnections);
+
+  useEffect(() => {
+    onConnectionsChange?.(conn.connections);
+  }, [conn.connections, onConnectionsChange]);
+
   const viewport = useCanvasViewport();
 
   const [dragOver, setDragOver] = useState(false);
+
+  // Keyboard: delete selected nodes
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.key === "Delete" || e.key === "Backspace") && selectedNodes.length > 0) {
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA") return;
+        selectedNodes.forEach((id) => conn.removeNodeConnections(id));
+        deleteSelectedNodes();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedNodes, deleteSelectedNodes, conn.removeNodeConnections]);
 
   // Node drag → update connection shapes imperatively
   const handleNodeDragMove = useCallback(
@@ -38,14 +115,15 @@ export default function DesignerCanvas() {
     (e: KonvaEventObject<MouseEvent>) => {
       if (e.target === e.target.getStage()) {
         conn.deselectConnection();
+        selectNode(null);
       }
     },
-    [conn.deselectConnection],
+    [conn.deselectConnection, selectNode],
   );
 
   // Drop from sidebar
   const handleDragOver = (e: React.DragEvent) => {
-    if (e.dataTransfer.types.includes("application/equipment")) {
+    if (e.dataTransfer.types.includes(EQUIPMENT_MIME_TYPE)) {
       e.preventDefault();
       e.dataTransfer.dropEffect = "copy";
       setDragOver(true);
@@ -58,7 +136,7 @@ export default function DesignerCanvas() {
     e.preventDefault();
     setDragOver(false);
 
-    const raw = e.dataTransfer.getData("application/equipment");
+    const raw = e.dataTransfer.getData(EQUIPMENT_MIME_TYPE);
     if (!raw) return;
 
     const { name, type } = JSON.parse(raw) as { name: string; type: NodeType };
@@ -106,6 +184,8 @@ export default function DesignerCanvas() {
         onClick={handleStageClick}
       >
         <Layer>
+          <CanvasGrid scale={viewport.scale} stagePos={viewport.stagePos} stageSize={viewport.stageSize} />
+
           {conn.connections.map((c) => {
             const from = nodeMap[c.from];
             const to = nodeMap[c.to];
@@ -147,8 +227,10 @@ export default function DesignerCanvas() {
               key={node.id}
               node={node}
               otherNodes={nodes.filter((n) => n.id !== node.id)}
+              selected={selectedNodes.includes(node.id)}
               isConnecting={!!conn.draggingFrom}
               draggingFromId={conn.draggingFrom}
+              onSelect={selectNode}
               onDragMove={handleNodeDragMove}
               onDragEnd={commitNodePosition}
               onOutputMouseDown={conn.startConnectionDrag}

--- a/app/designer/EquipmentSidebar.tsx
+++ b/app/designer/EquipmentSidebar.tsx
@@ -1,14 +1,21 @@
 import { useState } from "react";
-import { Search, Monitor, Server, Wifi, ChevronDown, ChevronRight } from "lucide-react";
+import { Search, Monitor, Server, Wifi, ChevronDown, ChevronRight, ChevronLeft } from "lucide-react";
 import { equipmentCategories, type EquipmentItem } from "./designer-data";
+import { typeIcons, EQUIPMENT_MIME_TYPE } from "./constants";
 
-const categoryIcons: Record<string, typeof Monitor> = {
-  workstation: Monitor,
-  server: Server,
-  switch: Wifi,
+const categoryIconMap: Record<string, typeof Monitor> = {
+  Workstations: Monitor,
+  Servers: Server,
+  Network: Wifi,
+  Peripherals: Monitor,
 };
 
-export default function EquipmentSidebar() {
+interface EquipmentSidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+export default function EquipmentSidebar({ collapsed, onToggle }: EquipmentSidebarProps) {
   const [search, setSearch] = useState("");
   const [expanded, setExpanded] = useState<Record<string, boolean>>(
     Object.fromEntries(equipmentCategories.map((c) => [c.name, c.expanded]))
@@ -20,16 +27,56 @@ export default function EquipmentSidebar() {
 
   const handleDragStart = (e: React.DragEvent, item: EquipmentItem) => {
     e.dataTransfer.setData(
-      "application/equipment",
+      EQUIPMENT_MIME_TYPE,
       JSON.stringify({ name: item.name, type: item.type })
     );
     e.dataTransfer.effectAllowed = "copy";
   };
 
+  if (collapsed) {
+    return (
+      <aside className="w-12 shrink-0 border-r border-border bg-white flex flex-col items-center pt-3 gap-3">
+        <button
+          onClick={onToggle}
+          className="p-1.5 rounded-lg hover:bg-surface transition-colors"
+          title="Expand panel"
+        >
+          <ChevronRight size={16} className="text-text-cool" />
+        </button>
+        <div className="w-6 h-px bg-border" />
+        {equipmentCategories.map((cat) => {
+          const Icon = categoryIconMap[cat.name] || Monitor;
+          return (
+            <button
+              key={cat.name}
+              onClick={onToggle}
+              className="w-8 h-8 rounded bg-primary/10 flex items-center justify-center hover:bg-primary/20 transition-colors"
+              title={cat.name}
+            >
+              <Icon size={14} className="text-primary" />
+            </button>
+          );
+        })}
+      </aside>
+    );
+  }
+
   return (
     <aside className="w-64 shrink-0 border-r border-border bg-white overflow-y-auto">
+      {/* Header with toggle */}
+      <div className="flex items-center justify-between px-3 pt-3 pb-1">
+        <span className="text-sm font-semibold text-text-cool">Equipment</span>
+        <button
+          onClick={onToggle}
+          className="p-1.5 rounded-lg hover:bg-surface transition-colors"
+          title="Collapse panel"
+        >
+          <ChevronLeft size={16} className="text-text-cool" />
+        </button>
+      </div>
+
       {/* Search */}
-      <div className="p-3">
+      <div className="px-3 pb-2">
         <div className="flex items-center gap-2 px-3 py-2 border border-border rounded-lg text-sm">
           <Search size={16} className="text-text-cool" />
           <input
@@ -44,46 +91,59 @@ export default function EquipmentSidebar() {
 
       {/* Categories */}
       <div className="px-3 pb-3">
-        {equipmentCategories.map((category) => (
-          <div key={category.name} className="mb-1">
-            <button
-              onClick={() => toggleCategory(category.name)}
-              className="flex items-center justify-between w-full py-2.5 text-sm font-semibold hover:text-primary transition-colors"
-            >
-              {category.name}
-              {expanded[category.name] ? (
-                <ChevronDown size={16} className="text-text-cool" />
-              ) : (
-                <ChevronRight size={16} className="text-text-cool" />
-              )}
-            </button>
+        {equipmentCategories.map((category) => {
+          const CatIcon = categoryIconMap[category.name] || Monitor;
+          return (
+            <div key={category.name} className="mb-1">
+              <button
+                onClick={() => toggleCategory(category.name)}
+                className="flex items-center justify-between w-full py-2.5 text-sm font-semibold hover:text-primary transition-colors"
+              >
+                <span className="flex items-center gap-2">
+                  <CatIcon size={14} className="text-text-cool" />
+                  {category.name}
+                </span>
+                <span className="flex items-center gap-1.5">
+                  {category.items.length > 0 && (
+                    <span className="text-xs text-text-cool bg-surface rounded-full px-1.5 py-0.5">
+                      {category.items.length}
+                    </span>
+                  )}
+                  {expanded[category.name] ? (
+                    <ChevronDown size={16} className="text-text-cool" />
+                  ) : (
+                    <ChevronRight size={16} className="text-text-cool" />
+                  )}
+                </span>
+              </button>
 
-            {expanded[category.name] && category.items.length > 0 && (
-              <div className="flex flex-col gap-1 mb-2">
-                {category.items
-                  .filter((item) =>
-                    item.name.toLowerCase().includes(search.toLowerCase())
-                  )
-                  .map((item) => {
-                    const Icon = categoryIcons[item.type] || Monitor;
-                    return (
-                      <div
-                        key={item.id}
-                        draggable
-                        onDragStart={(e) => handleDragStart(e, item)}
-                        className="flex items-center gap-2.5 px-2 py-2.5 rounded-lg border border-border text-sm cursor-grab active:cursor-grabbing hover:bg-surface hover:border-primary/30 transition-colors select-none"
-                      >
-                        <div className="w-8 h-8 rounded bg-primary/10 flex items-center justify-center">
-                          <Icon size={14} className="text-primary" />
+              {expanded[category.name] && category.items.length > 0 && (
+                <div className="flex flex-col gap-1 mb-2">
+                  {category.items
+                    .filter((item) =>
+                      item.name.toLowerCase().includes(search.toLowerCase())
+                    )
+                    .map((item) => {
+                      const Icon = typeIcons[item.type] || Monitor;
+                      return (
+                        <div
+                          key={item.id}
+                          draggable
+                          onDragStart={(e) => handleDragStart(e, item)}
+                          className="flex items-center gap-2.5 px-2 py-2.5 rounded-lg border border-border text-sm cursor-grab active:cursor-grabbing active:opacity-50 hover:bg-surface hover:border-primary/30 transition-colors select-none"
+                        >
+                          <div className="w-8 h-8 rounded bg-primary/10 flex items-center justify-center">
+                            <Icon size={14} className="text-primary" />
+                          </div>
+                          {item.name}
                         </div>
-                        {item.name}
-                      </div>
-                    );
-                  })}
-              </div>
-            )}
-          </div>
-        ))}
+                      );
+                    })}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </aside>
   );

--- a/app/designer/NodeShape.tsx
+++ b/app/designer/NodeShape.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useCallback } from "react";
+import { useState } from "react";
 import { Rect, Text, Line, Group, Circle } from "react-konva";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type Konva from "konva";
 import type { CanvasNode } from "./designer-data";
-import { NODE_W, NODE_H, NODE_PADDING, PORT_RADIUS, ACCENT_COLOR, typeColors } from "./constants";
+import { NODE_W, NODE_H, PORT_RADIUS, ACCENT_COLOR, SELECTED_COLOR, typeColors } from "./constants";
 
 // --- Port: circular connection point ---
 function Port({
@@ -70,13 +70,14 @@ function Port({
 function DeviceIcon({ type, x, y }: { type: string; x: number; y: number }) {
   const cx = x + NODE_W / 2;
   const cy = y + 45;
+  const color = typeColors[type]?.stroke ?? ACCENT_COLOR;
 
   if (type === "server") {
     return (
       <Group listening={false}>
-        <Rect x={cx - 16} y={cy - 18} width={32} height={12} fill="#42EB90" cornerRadius={2} />
-        <Rect x={cx - 16} y={cy - 3} width={32} height={12} fill="#42EB90" cornerRadius={2} />
-        <Rect x={cx - 16} y={cy + 12} width={32} height={12} fill="#42EB90" cornerRadius={2} />
+        <Rect x={cx - 16} y={cy - 18} width={32} height={12} fill={color} cornerRadius={2} />
+        <Rect x={cx - 16} y={cy - 3} width={32} height={12} fill={color} cornerRadius={2} />
+        <Rect x={cx - 16} y={cy + 12} width={32} height={12} fill={color} cornerRadius={2} />
       </Group>
     );
   }
@@ -84,7 +85,7 @@ function DeviceIcon({ type, x, y }: { type: string; x: number; y: number }) {
   if (type === "switch") {
     return (
       <Group listening={false}>
-        <Rect x={cx - 16} y={cy - 10} width={32} height={24} fill="#0D7A8A" cornerRadius={4} />
+        <Rect x={cx - 16} y={cy - 10} width={32} height={24} fill={color} cornerRadius={4} />
         <Line points={[cx - 8, cy + 2, cx, cy - 4, cx + 8, cy + 2]} stroke="white" strokeWidth={2} />
         <Line points={[cx - 4, cy + 6, cx, cy + 2, cx + 4, cy + 6]} stroke="white" strokeWidth={2} />
       </Group>
@@ -93,9 +94,9 @@ function DeviceIcon({ type, x, y }: { type: string; x: number; y: number }) {
 
   return (
     <Group listening={false}>
-      <Rect x={cx - 14} y={cy - 12} width={28} height={20} fill="#0D7A8A" cornerRadius={2} />
-      <Rect x={cx - 6} y={cy + 10} width={12} height={3} fill="#0D7A8A" cornerRadius={1} />
-      <Line points={[cx, cy + 8, cx, cy + 10]} stroke="#0D7A8A" strokeWidth={2} />
+      <Rect x={cx - 14} y={cy - 12} width={28} height={20} fill={color} cornerRadius={2} />
+      <Rect x={cx - 6} y={cy + 10} width={12} height={3} fill={color} cornerRadius={1} />
+      <Line points={[cx, cy + 8, cx, cy + 10]} stroke={color} strokeWidth={2} />
     </Group>
   );
 }
@@ -104,8 +105,10 @@ function DeviceIcon({ type, x, y }: { type: string; x: number; y: number }) {
 export default function NodeShape({
   node,
   otherNodes,
+  selected,
   isConnecting,
   draggingFromId,
+  onSelect,
   onDragMove,
   onDragEnd,
   onOutputMouseDown,
@@ -113,8 +116,10 @@ export default function NodeShape({
 }: {
   node: CanvasNode;
   otherNodes: CanvasNode[];
+  selected: boolean;
   isConnecting: boolean;
   draggingFromId: string | null;
+  onSelect: (id: string, shiftKey: boolean) => void;
   onDragMove: (id: string, group: Konva.Group) => void;
   onDragEnd: (id: string, x: number, y: number) => void;
   onOutputMouseDown: (nodeId: string) => void;
@@ -123,61 +128,29 @@ export default function NodeShape({
   const colors = typeColors[node.type];
   const compatibleTarget = isConnecting && draggingFromId !== node.id;
 
-  const otherNodesRef = useRef(otherNodes);
-  otherNodesRef.current = otherNodes;
-
-  const dragBoundFunc = useCallback(
-    (pos: { x: number; y: number }) => {
-      const others = otherNodesRef.current;
-      let { x, y } = pos;
-
-      x = Math.max(0, x);
-      y = Math.max(0, y);
-
-      for (const other of others) {
-        const overlapX = x < other.x + NODE_W + NODE_PADDING && x + NODE_W + NODE_PADDING > other.x;
-        const overlapY = y < other.y + NODE_H + NODE_PADDING && y + NODE_H + NODE_PADDING > other.y;
-
-        if (overlapX && overlapY) {
-          const pushRight = other.x + NODE_W + NODE_PADDING - x;
-          const pushLeft = x + NODE_W + NODE_PADDING - other.x;
-          const pushDown = other.y + NODE_H + NODE_PADDING - y;
-          const pushUp = y + NODE_H + NODE_PADDING - other.y;
-
-          const minPush = Math.min(pushRight, pushLeft, pushDown, pushUp);
-
-          if (minPush === pushRight) x = other.x + NODE_W + NODE_PADDING;
-          else if (minPush === pushLeft) x = other.x - NODE_W - NODE_PADDING;
-          else if (minPush === pushDown) y = other.y + NODE_H + NODE_PADDING;
-          else y = other.y - NODE_H - NODE_PADDING;
-        }
-      }
-
-      return { x: Math.max(0, x), y: Math.max(0, y) };
-    },
-    [],
-  );
-
   return (
     <Group
       id={node.id}
       x={node.x}
       y={node.y}
       draggable
-      dragBoundFunc={dragBoundFunc}
       onDragMove={(e: KonvaEventObject<DragEvent>) => {
         onDragMove(node.id, e.target as unknown as Konva.Group);
       }}
       onDragEnd={(e: KonvaEventObject<DragEvent>) => {
         onDragEnd(node.id, e.target.x(), e.target.y());
       }}
+      onClick={(e: KonvaEventObject<MouseEvent>) => {
+        e.cancelBubble = true;
+        onSelect(node.id, e.evt.shiftKey);
+      }}
     >
       <Rect
         width={NODE_W}
         height={NODE_H}
         fill="white"
-        stroke={colors.stroke}
-        strokeWidth={2}
+        stroke={selected ? SELECTED_COLOR : colors.stroke}
+        strokeWidth={selected ? 3 : 2}
         cornerRadius={8}
         shadowColor="rgba(0,0,0,0.08)"
         shadowBlur={4}

--- a/app/designer/PropertiesPanel.tsx
+++ b/app/designer/PropertiesPanel.tsx
@@ -1,16 +1,42 @@
-import { useState } from "react";
-import { Wallet } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Wallet, ChevronLeft, ChevronRight, Monitor, MousePointer, ArrowRight, ArrowLeft } from "lucide-react";
+import type { CanvasNode, Connection } from "./designer-data";
 import { defaultProperties } from "./designer-data";
+import { typeIcons, typeLabels, STORAGE_KEYS } from "./constants";
 
 interface PropertiesPanelProps {
   activeTab: string;
   onTabChange: (tab: string) => void;
+  collapsed: boolean;
+  onToggle: () => void;
+  selectedNodes: CanvasNode[];
+  allNodes: CanvasNode[];
+  connections: Connection[];
 }
 
 const tabs = ["Properties", "Connections", "Notes"];
 
-export default function PropertiesPanel({ activeTab, onTabChange }: PropertiesPanelProps) {
+export default function PropertiesPanel({
+  activeTab,
+  onTabChange,
+  collapsed,
+  onToggle,
+  selectedNodes,
+  allNodes,
+  connections,
+}: PropertiesPanelProps) {
   const [selectedStorage, setSelectedStorage] = useState([defaultProperties.storage[0]]);
+  const [notes, setNotes] = useState<Record<string, string>>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEYS.NOTES);
+      if (saved) return JSON.parse(saved);
+    } catch {}
+    return {};
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEYS.NOTES, JSON.stringify(notes));
+  }, [notes]);
 
   const toggleStorage = (s: string) => {
     setSelectedStorage((prev) =>
@@ -18,8 +44,72 @@ export default function PropertiesPanel({ activeTab, onTabChange }: PropertiesPa
     );
   };
 
+  if (collapsed) {
+    return (
+      <aside className="w-10 shrink-0 border-l border-border bg-white flex flex-col items-center pt-3">
+        <button
+          onClick={onToggle}
+          className="p-1.5 rounded-lg hover:bg-surface transition-colors"
+          title="Expand panel"
+        >
+          <ChevronLeft size={16} className="text-text-cool" />
+        </button>
+      </aside>
+    );
+  }
+
+  const node = selectedNodes.length === 1 ? selectedNodes[0] : null;
+  const TypeIcon = node ? (typeIcons[node.type] || Monitor) : null;
+  const selectedIds = new Set(selectedNodes.map((n) => n.id));
+
+  const relevantConnections = connections.filter(
+    (c) => selectedIds.has(c.from) || selectedIds.has(c.to)
+  );
+
+  const currentNote = node ? (notes[node.id] ?? "") : "";
+
   return (
     <aside className="w-72 shrink-0 border-l border-border bg-white overflow-y-auto flex flex-col">
+      {/* Header with toggle + node count */}
+      <div className="flex items-center justify-between px-4 pt-3 pb-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-text-cool">Inspector</span>
+          <span className="text-xs text-text-cool bg-surface rounded-full px-1.5 py-0.5">
+            {allNodes.length}
+          </span>
+        </div>
+        <button
+          onClick={onToggle}
+          className="p-1.5 rounded-lg hover:bg-surface transition-colors"
+          title="Collapse panel"
+        >
+          <ChevronRight size={16} className="text-text-cool" />
+        </button>
+      </div>
+
+      {/* Selected node header */}
+      {node && TypeIcon && (
+        <div className="px-4 py-3 border-b border-border">
+          <div className="flex items-center gap-2.5">
+            <div className="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center">
+              <TypeIcon size={16} className="text-primary" />
+            </div>
+            <div>
+              <p className="text-sm font-medium">{node.label.replace("\n", " ")}</p>
+              <p className="text-xs text-text-cool">{typeLabels[node.type] || node.type}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Multi-selection header */}
+      {selectedNodes.length > 1 && (
+        <div className="px-4 py-3 border-b border-border">
+          <p className="text-sm font-medium">{selectedNodes.length} elements selected</p>
+          <p className="text-xs text-text-cool">Shift+click to modify selection</p>
+        </div>
+      )}
+
       {/* Tabs */}
       <div className="flex border-b border-border">
         {tabs.map((tab) => (
@@ -37,11 +127,22 @@ export default function PropertiesPanel({ activeTab, onTabChange }: PropertiesPa
         ))}
       </div>
 
-      {activeTab === "Properties" && (
+      {/* Properties - empty state */}
+      {selectedNodes.length === 0 && activeTab === "Properties" && (
+        <div className="flex-1 flex flex-col items-center justify-center p-6 text-center">
+          <div className="w-12 h-12 rounded-full bg-surface flex items-center justify-center mb-3">
+            <MousePointer size={20} className="text-text-cool" />
+          </div>
+          <p className="text-sm font-medium text-text-cool">No element selected</p>
+          <p className="text-xs text-text-cool mt-1">Click on a node to view its properties</p>
+        </div>
+      )}
+
+      {/* Properties - form */}
+      {selectedNodes.length > 0 && activeTab === "Properties" && (
         <div className="p-5 flex-1 flex flex-col">
           <h3 className="text-base font-semibold mb-4">Configuration</h3>
 
-          {/* CPU Model */}
           <div className="mb-4">
             <label className="text-sm text-text-cool mb-1.5 block">CPU Model</label>
             <select className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-white">
@@ -51,7 +152,6 @@ export default function PropertiesPanel({ activeTab, onTabChange }: PropertiesPa
             </select>
           </div>
 
-          {/* RAM */}
           <div className="mb-4">
             <div className="flex items-center justify-between mb-1.5">
               <label className="text-sm text-text-cool">RAM</label>
@@ -67,7 +167,6 @@ export default function PropertiesPanel({ activeTab, onTabChange }: PropertiesPa
             />
           </div>
 
-          {/* Storage */}
           <div className="mb-6">
             <label className="text-sm text-text-cool mb-1.5 block">Storage</label>
             <div className="flex flex-col gap-2">
@@ -85,7 +184,6 @@ export default function PropertiesPanel({ activeTab, onTabChange }: PropertiesPa
             </div>
           </div>
 
-          {/* Estimated Price */}
           <div className="mt-auto p-4 bg-primary rounded-xl text-white">
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm font-medium opacity-90">Estimated Price</span>
@@ -95,21 +193,75 @@ export default function PropertiesPanel({ activeTab, onTabChange }: PropertiesPa
               ${defaultProperties.estimatedPrice.toLocaleString()}.00
             </p>
             <p className="text-xs text-accent mt-1">
-              Per unit &bull; {defaultProperties.selectedCount} selected
+              Per unit &bull; {selectedNodes.length} selected
             </p>
           </div>
         </div>
       )}
 
-      {activeTab === "Connections" && (
-        <div className="p-5">
-          <p className="text-sm text-text-cool">Connection details will appear here when a link is selected.</p>
+      {/* Connections - empty state */}
+      {selectedNodes.length === 0 && activeTab === "Connections" && (
+        <div className="flex-1 flex flex-col items-center justify-center p-6 text-center">
+          <p className="text-sm text-text-cool">Select an element to see its connections.</p>
         </div>
       )}
 
-      {activeTab === "Notes" && (
+      {/* Connections - list */}
+      {selectedNodes.length > 0 && activeTab === "Connections" && (
+        <div className="p-4 flex-1">
+          {relevantConnections.length === 0 ? (
+            <p className="text-sm text-text-cool">No connections.</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {relevantConnections.map((c) => {
+                const fromNode = allNodes.find((n) => n.id === c.from);
+                const toNode = allNodes.find((n) => n.id === c.to);
+                if (!fromNode || !toNode) return null;
+                const isOutgoing = selectedIds.has(c.from);
+                const otherNode = isOutgoing ? toNode : fromNode;
+                const OtherIcon = typeIcons[otherNode.type] || Monitor;
+                return (
+                  <div
+                    key={`${c.from}-${c.to}`}
+                    className="flex items-center gap-2.5 p-2.5 rounded-lg border border-border text-sm"
+                  >
+                    {isOutgoing ? (
+                      <ArrowRight size={14} className="text-primary shrink-0" />
+                    ) : (
+                      <ArrowLeft size={14} className="text-primary shrink-0" />
+                    )}
+                    <div className="w-7 h-7 rounded bg-primary/10 flex items-center justify-center shrink-0">
+                      <OtherIcon size={12} className="text-primary" />
+                    </div>
+                    <span className="truncate">{otherNode.label.replace("\n", " ")}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Notes - empty state */}
+      {selectedNodes.length === 0 && activeTab === "Notes" && (
+        <div className="flex-1 flex flex-col items-center justify-center p-6 text-center">
+          <p className="text-sm text-text-cool">Select an element to add notes.</p>
+        </div>
+      )}
+
+      {/* Notes - multi-selection */}
+      {selectedNodes.length > 1 && activeTab === "Notes" && (
+        <div className="p-5">
+          <p className="text-sm text-text-cool">Select a single element to edit notes.</p>
+        </div>
+      )}
+
+      {/* Notes - single selection */}
+      {node && activeTab === "Notes" && (
         <div className="p-5">
           <textarea
+            value={currentNote}
+            onChange={(e) => setNotes((prev) => ({ ...prev, [node.id]: e.target.value }))}
             className="w-full h-32 text-sm border border-border rounded-lg p-3 resize-none"
             placeholder="Add notes about this element..."
           />

--- a/app/designer/constants.ts
+++ b/app/designer/constants.ts
@@ -1,3 +1,6 @@
+import { Monitor, Server, Wifi } from "lucide-react";
+
+export const GRID_SIZE = 20;
 export const NODE_W = 140;
 export const NODE_H = 130;
 export const NODE_PADDING = 20;
@@ -11,3 +14,23 @@ export const typeColors: Record<string, { stroke: string }> = {
   switch: { stroke: ACCENT_COLOR },
   workstation: { stroke: "#E5E7EB" },
 };
+
+export const typeIcons: Record<string, typeof Monitor> = {
+  server: Server,
+  switch: Wifi,
+  workstation: Monitor,
+};
+
+export const typeLabels: Record<string, string> = {
+  server: "Server",
+  switch: "Network Switch",
+  workstation: "Workstation",
+};
+
+export const STORAGE_KEYS = {
+  NODES: "designer-nodes",
+  CONNECTIONS: "designer-connections",
+  NOTES: "designer-notes",
+} as const;
+
+export const EQUIPMENT_MIME_TYPE = "application/equipment";

--- a/app/designer/designer-data.ts
+++ b/app/designer/designer-data.ts
@@ -85,7 +85,6 @@ export interface PropertyConfig {
   ram: number;
   storage: string[];
   estimatedPrice: number;
-  selectedCount: number;
 }
 
 export const defaultProperties: PropertyConfig = {
@@ -93,5 +92,4 @@ export const defaultProperties: PropertyConfig = {
   ram: 32,
   storage: ["512GB NVMe SSD", "1TB SATA SSD", "2TB HDD"],
   estimatedPrice: 2450,
-  selectedCount: 3,
 };

--- a/app/designer/page.tsx
+++ b/app/designer/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import dynamic from "next/dynamic";
+import type { CanvasNode, Connection } from "./designer-data";
 import EquipmentSidebar from "./EquipmentSidebar";
 import DesignerToolbar from "./DesignerToolbar";
 import PropertiesPanel from "./PropertiesPanel";
@@ -11,17 +12,34 @@ const DesignerCanvas = dynamic(() => import("./DesignerCanvas"), { ssr: false })
 export default function DesignerPage() {
   const [activeView, setActiveView] = useState("Grid");
   const [activeTab, setActiveTab] = useState("Properties");
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+  const [rightCollapsed, setRightCollapsed] = useState(false);
+  const [selectedNodes, setSelectedNodes] = useState<CanvasNode[]>([]);
+  const [allNodes, setAllNodes] = useState<CanvasNode[]>([]);
+  const [connections, setConnections] = useState<Connection[]>([]);
 
   return (
     <div className="flex h-full">
-      <EquipmentSidebar />
+      <EquipmentSidebar collapsed={leftCollapsed} onToggle={() => setLeftCollapsed(!leftCollapsed)} />
 
       <div className="flex-1 flex flex-col">
         <DesignerToolbar activeView={activeView} onViewChange={setActiveView} />
-        <DesignerCanvas />
+        <DesignerCanvas
+          onSelectionChange={setSelectedNodes}
+          onNodesChange={setAllNodes}
+          onConnectionsChange={setConnections}
+        />
       </div>
 
-      <PropertiesPanel activeTab={activeTab} onTabChange={setActiveTab} />
+      <PropertiesPanel
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        collapsed={rightCollapsed}
+        onToggle={() => setRightCollapsed(!rightCollapsed)}
+        selectedNodes={selectedNodes}
+        allNodes={allNodes}
+        connections={connections}
+      />
     </div>
   );
 }

--- a/app/designer/useCanvasNodes.ts
+++ b/app/designer/useCanvasNodes.ts
@@ -1,6 +1,10 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { CanvasNode, NodeType } from "./designer-data";
-import { NODE_W, NODE_H, NODE_PADDING } from "./constants";
+import { NODE_W, NODE_H, NODE_PADDING, GRID_SIZE, STORAGE_KEYS } from "./constants";
+
+function snap(v: number) {
+  return Math.round(v / GRID_SIZE) * GRID_SIZE;
+}
 
 export function resolveOverlap(
   x: number,
@@ -35,20 +39,64 @@ export function resolveOverlap(
     if (!overlapping) break;
   }
 
-  return { x: Math.max(0, nx), y: Math.max(0, ny) };
+  return { x: nx, y: ny };
+}
+
+const STORAGE_KEY = STORAGE_KEYS.NODES;
+
+function getMaxId(nodes: CanvasNode[]): number {
+  return nodes.reduce((max, n) => {
+    const num = parseInt(n.id.replace("node-", ""), 10);
+    return isNaN(num) ? max : Math.max(max, num);
+  }, 0);
 }
 
 let nextId = 0;
 
 export function useCanvasNodes(initial: CanvasNode[]) {
   const [nodes, setNodes] = useState<CanvasNode[]>(() => {
-    nextId = initial.length + 1;
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const parsed: CanvasNode[] = JSON.parse(saved);
+        nextId = getMaxId(parsed) + 1;
+        return parsed;
+      }
+    } catch {}
+    nextId = getMaxId(initial) + 1;
     return initial;
   });
 
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(nodes));
+  }, [nodes]);
+
+  const [selectedNodes, setSelectedNodes] = useState<string[]>([]);
+
+  const selectNode = useCallback((id: string | null, shiftKey?: boolean) => {
+    if (!id) {
+      setSelectedNodes([]);
+      return;
+    }
+    if (shiftKey) {
+      setSelectedNodes((prev) =>
+        prev.includes(id) ? prev.filter((n) => n !== id) : [...prev, id],
+      );
+    } else {
+      setSelectedNodes([id]);
+    }
+  }, []);
+
+  const deleteSelectedNodes = useCallback(() => {
+    setSelectedNodes((sel) => {
+      setNodes((prev) => prev.filter((n) => !sel.includes(n.id)));
+      return [];
+    });
+  }, []);
+
   const commitNodePosition = useCallback((id: string, x: number, y: number) => {
     setNodes((prev) => {
-      const resolved = resolveOverlap(x, y, id, prev);
+      const resolved = resolveOverlap(snap(x), snap(y), id, prev);
       return prev.map((n) => (n.id === id ? { ...n, ...resolved } : n));
     });
   }, []);
@@ -56,10 +104,10 @@ export function useCanvasNodes(initial: CanvasNode[]) {
   const addNode = useCallback((name: string, type: NodeType, x: number, y: number) => {
     const newId = `node-${nextId++}`;
     setNodes((prev) => {
-      const resolved = resolveOverlap(Math.max(0, x), Math.max(0, y), newId, prev);
+      const resolved = resolveOverlap(snap(x), snap(y), newId, prev);
       return [...prev, { id: newId, type, label: name, ...resolved }];
     });
   }, []);
 
-  return { nodes, commitNodePosition, addNode };
+  return { nodes, selectedNodes, selectNode, deleteSelectedNodes, commitNodePosition, addNode };
 }

--- a/app/designer/useConnections.ts
+++ b/app/designer/useConnections.ts
@@ -2,10 +2,28 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type Konva from "konva";
 import type { Connection, Waypoint } from "./designer-data";
-import { NODE_W, NODE_H } from "./constants";
+import { NODE_W, NODE_H, STORAGE_KEYS } from "./constants";
+
+function parseConnKey(key: string): [string, string] {
+  const [from, to] = key.split("->>");
+  return [from, to];
+}
+
+const STORAGE_KEY = STORAGE_KEYS.CONNECTIONS;
 
 export function useConnections(initial: Connection[]) {
-  const [connections, setConnections] = useState<Connection[]>(initial);
+  const [connections, setConnections] = useState<Connection[]>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) return JSON.parse(saved);
+    } catch {}
+    return initial;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(connections));
+  }, [connections]);
+
   const [draggingFrom, setDraggingFrom] = useState<string | null>(null);
   const [dragTarget, setDragTarget] = useState<{ x: number; y: number } | null>(null);
   const [selectedConnection, setSelectedConnection] = useState<string | null>(null);
@@ -18,7 +36,7 @@ export function useConnections(initial: Connection[]) {
         const tag = (e.target as HTMLElement).tagName;
         if (tag === "INPUT" || tag === "TEXTAREA") return;
 
-        const [from, to] = selectedConnection.split("->>");
+        const [from, to] = parseConnKey(selectedConnection);
         setConnections((prev) => prev.filter((c) => !(c.from === from && c.to === to)));
         setSelectedConnection(null);
       }
@@ -94,7 +112,7 @@ export function useConnections(initial: Connection[]) {
   const handleConnectionContextMenu = useCallback(
     (connKey: string, e: KonvaEventObject<PointerEvent>) => {
       e.evt.preventDefault();
-      const [from, to] = connKey.split("->>");
+      const [from, to] = parseConnKey(connKey);
       setConnections((prev) => prev.filter((c) => !(c.from === from && c.to === to)));
       setSelectedConnection(null);
     },
@@ -124,7 +142,7 @@ export function useConnections(initial: Connection[]) {
   // --- Waypoint handlers ---
   const addWaypoint = useCallback(
     (connKey: string, x: number, y: number, segmentIndex: number) => {
-      const [from, to] = connKey.split("->>");
+      const [from, to] = parseConnKey(connKey);
       setConnections((prev) =>
         prev.map((c) => {
           if (c.from !== from || c.to !== to) return c;
@@ -140,7 +158,7 @@ export function useConnections(initial: Connection[]) {
 
   const moveWaypoint = useCallback(
     (connKey: string, wpIndex: number, x: number, y: number) => {
-      const [from, to] = connKey.split("->>");
+      const [from, to] = parseConnKey(connKey);
       setConnections((prev) =>
         prev.map((c) => {
           if (c.from !== from || c.to !== to) return c;
@@ -157,7 +175,7 @@ export function useConnections(initial: Connection[]) {
 
   const removeWaypoint = useCallback(
     (connKey: string, wpIndex: number) => {
-      const [from, to] = connKey.split("->>");
+      const [from, to] = parseConnKey(connKey);
       setConnections((prev) =>
         prev.map((c) => {
           if (c.from !== from || c.to !== to) return c;
@@ -169,6 +187,10 @@ export function useConnections(initial: Connection[]) {
     },
     [],
   );
+
+  const removeNodeConnections = useCallback((nodeId: string) => {
+    setConnections((prev) => prev.filter((c) => c.from !== nodeId && c.to !== nodeId));
+  }, []);
 
   return {
     connections,
@@ -188,5 +210,6 @@ export function useConnections(initial: Connection[]) {
     moveWaypoint,
     onWaypointDragEnd,
     removeWaypoint,
+    removeNodeConnections,
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -30,5 +36,7 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
# Description

- Add grid dot background on canvas with adaptive density
- Implement single and multi-selection (shift+click) with visual feedback
- Make sidebar and properties panel collapsible with toggle buttons
- Persist nodes, connections and notes in localStorage
- Add Delete/Backspace support to remove selected nodes and their connections
- Wire inspector panel to display selected node details, connections list and per-node notes
- Snap node positions to grid on drop/drag end
- Fix pointer coordinate calculation to account for stage offset
- Centralize shared constants (icons, labels, MIME type, storage keys)

Closes #38 #50 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test with moving components and liks, and tinkering with menus

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
